### PR TITLE
Audio tweaks

### DIFF
--- a/hdl/imageGen.sv
+++ b/hdl/imageGen.sv
@@ -59,7 +59,7 @@ module imageGenV
   output logic tmdsClk  
 );
 
-localparam audioDamp = 6;
+localparam audioDamp = 2;
 
 wire audioClk_gba, audioValid;
 logic [AUDIO_BIT_WIDTH-1:0] pcmL, pcmR, audioL, audioR;
@@ -78,7 +78,7 @@ pwm2pcm #( .clkFreq0( pxlClkFrq_60hz ),
            .clkFreq1( pxlClkFrq_59hz ),
            .clkFreqMax( pxlClkFrq_60hz ),
            .sampleFreq( 48.0 ),
-           .damp( 2 ) )
+           .damp( audioDamp ) )
 pwm2pcm( .pwmInL( audioLIn ), 
          .pwmInR( audioRIn ), 
          .clk( pxlClk ), 

--- a/hdl/pwm2pcm.vhd
+++ b/hdl/pwm2pcm.vhd
@@ -37,10 +37,11 @@ architecture rtl of pwm2pcm is
 constant maxCntClk : integer := integer( ceil( clkFreqMax / sampleFreq ) ) - 1;
 constant maxHighCnt : integer := integer( ceil( clkFreqMax / 65.5360 ) ) - 1;
 constant highCntBits : integer := integer( ceil( log2( real( maxHighCnt + 1) ) ) );
+constant highCntOffset : integer := maxHighCnt / 2;
 signal cnt : integer range 0 to maxCntClk;
 signal highCntL : unsigned( highCntBits - 1 downto 0 );
 signal highCntR : unsigned( highCntBits - 1 downto 0 );
-signal curSampleL, curSampleR : std_logic_vector( 15 downto 0 );
+signal curSampleL, curSampleR : signed( 15 downto 0 );
 signal pwmInL_prev, pwmInR_prev: std_logic;
 
 constant maxCntSampleClk0 : integer := integer( floor( clkFreq0 / ( sampleFreq ) ) ) - 1;
@@ -56,8 +57,8 @@ signal pwmL_int, pwmR_int : std_logic;
 
 begin
 
-  datOutL <= curSampleL;
-  datOutR <= curSampleR;
+  datOutL <= std_logic_vector( curSampleL );
+  datOutR <= std_logic_vector( curSampleR );
   
   -- Filter
   process( clk ) is
@@ -100,7 +101,7 @@ begin
   end process;
   
   process( clk ) is
-  variable tmpCurSampleL, tmpCurSampleR : unsigned( 15 downto 0 );
+  variable tmpCurSampleL, tmpCurSampleR : signed( 15 downto 0 );
   begin
     if ( rising_edge( clk ) ) then
       if ( rst = '1' ) then
@@ -118,10 +119,10 @@ begin
           highCntL <= ( others => '0' );
           
           tmpCurSampleL := ( others => '0' );
-          tmpCurSampleL( 15 downto ( 16 - highCntBits ) ) := highCntL;
+          tmpCurSampleL( 15 downto ( 16 - highCntBits ) ) := signed(highCntL - to_unsigned(highCntOffset, highCntL'length));
           tmpCurSampleL := shift_right( tmpCurSampleL, damp );
           
-          curSampleL <= std_logic_vector( tmpCurSampleL );
+          curSampleL <= tmpCurSampleL;
           
         elsif ( pwmL_int = '1' ) then
           highCntL <= highCntL + 1;
@@ -134,10 +135,10 @@ begin
           highCntR <= ( others => '0' );
           
           tmpCurSampleR := ( others => '0' );
-          tmpCurSampleR( 15 downto ( 16 - highCntBits ) ) := highCntR;
+          tmpCurSampleR( 15 downto ( 16 - highCntBits ) ) := signed(highCntR - to_unsigned(highCntOffset, highCntR'length));
           tmpCurSampleR := shift_right( tmpCurSampleR, damp );
           
-          curSampleR <= std_logic_vector( tmpCurSampleR );
+          curSampleR <= tmpCurSampleR;
           
         elsif ( pwmR_int = '1' ) then
           highCntR <= highCntR + 1;

--- a/hdl/pwm2pcm.vhd
+++ b/hdl/pwm2pcm.vhd
@@ -38,8 +38,8 @@ constant maxCntClk : integer := integer( ceil( clkFreqMax / sampleFreq ) ) - 1;
 constant maxHighCnt : integer := integer( ceil( clkFreqMax / 65.5360 ) ) - 1;
 constant highCntBits : integer := integer( ceil( log2( real( maxHighCnt ) ) ) ) + 1;
 signal cnt : integer range 0 to maxCntClk;
-signal highCntL, lowCntL, diffL : unsigned( highCntBits - 1 downto 0 );
-signal highCntR, lowCntR, diffR : unsigned( highCntBits - 1 downto 0 );
+signal highCntL : unsigned( highCntBits - 1 downto 0 );
+signal highCntR : unsigned( highCntBits - 1 downto 0 );
 signal curSampleL, curSampleR : std_logic_vector( 15 downto 0 );
 signal pwmInL_prev, pwmInR_prev: std_logic;
 
@@ -105,24 +105,17 @@ begin
     if ( rising_edge( clk ) ) then
       if ( rst = '1' ) then
         highCntL <= ( others => '0' );
-        lowCntL <= ( others => '0' );
         pwmInL_prev <= '0';
         curSampleL <= ( others => '0' );
-        diffL <= ( others => '0' );
         
         highCntR <= ( others => '0' );
-        lowCntR <= ( others => '0' );
         pwmInR_prev <= '0';
         curSampleR <= ( others => '0' );
-        diffR <= ( others => '0' );
       else
         pwmInL_prev <= pwmL_int;
         
         if ( pwmInL_prev = '0'  and pwmL_int = '1' ) then
           highCntL <= ( others => '0' );
-          lowCntL <= ( others => '0' );
-          
-          diffL <= highCntL - lowCntL;
           
           tmpCurSampleL := ( others => '0' );
           tmpCurSampleL( 15 downto ( 16 - highCntBits ) ) := highCntL;
@@ -132,8 +125,6 @@ begin
           
         elsif ( pwmL_int = '1' ) then
           highCntL <= highCntL + 1;
-        else
-          lowCntL <= lowCntL + 1;
         end if;
         
         
@@ -141,9 +132,6 @@ begin
         
         if ( pwmInR_prev = '0'  and pwmR_int = '1' ) then
           highCntR <= ( others => '0' );
-          lowCntR <= ( others => '0' );
-          
-          diffR <= highCntR - lowCntR;
           
           tmpCurSampleR := ( others => '0' );
           tmpCurSampleR( 15 downto ( 16 - highCntBits ) ) := highCntR;
@@ -153,8 +141,6 @@ begin
           
         elsif ( pwmR_int = '1' ) then
           highCntR <= highCntR + 1;
-        else
-          lowCntR <= lowCntR + 1;
         end if;
         
       end if;

--- a/hdl/pwm2pcm.vhd
+++ b/hdl/pwm2pcm.vhd
@@ -36,7 +36,7 @@ end pwm2pcm;
 architecture rtl of pwm2pcm is
 constant maxCntClk : integer := integer( ceil( clkFreqMax / sampleFreq ) ) - 1;
 constant maxHighCnt : integer := integer( ceil( clkFreqMax / 65.5360 ) ) - 1;
-constant highCntBits : integer := integer( ceil( log2( real( maxHighCnt ) ) ) ) + 1;
+constant highCntBits : integer := integer( ceil( log2( real( maxHighCnt + 1) ) ) );
 signal cnt : integer range 0 to maxCntClk;
 signal highCntL : unsigned( highCntBits - 1 downto 0 );
 signal highCntR : unsigned( highCntBits - 1 downto 0 );


### PR DESCRIPTION
This makes a few improvements to the audio output:

1. Output signed samples (as required by HDMI) instead of unsigned.  The current implementation gets away with using unsigned values because DC offsets are inaudible and the dynamic range is such that the MSB never gets set (which would cause overflow and severe distortion).  A side effect is that naive VU meters that track absolute level instead of RMS (such as the one in OBS studio) constantly show volume in the red.
2. Apply a modest IIR low-pass filter.  This attenuates some high-frequency noise that is audible with low `damp` or high gain in the audio path.  It doesn't completely eliminate it, but maybe it can be tweaked further.

Example waveform in audacity before the changes.  Note the DC offset from 0 and the noise during the "silent" section after the GBA boot screen:

![bad](https://user-images.githubusercontent.com/2101303/149053443-b0ab8dd8-730a-4738-9ad0-e0791b21869e.png)

Example waveform after the changes:

![good](https://user-images.githubusercontent.com/2101303/149053464-cc8b8226-0ad6-49d6-82bd-803b6b90eb11.png)

There's also a few minor related fixes.  Forgive me if I did anything silly, this is the first time I've touched HDL since a college class I took over a decade ago.