### PR TITLE
hdl-make support

### DIFF
--- a/hdl/Manifest.py
+++ b/hdl/Manifest.py
@@ -1,0 +1,20 @@
+files = [
+    "borderGen.vhd",
+    "captureGBA.vhd",
+    "commTransceiver.vhd",
+    "definePackage.sv",
+    "drp.vhd",
+    "font5x7.vhd",
+    "fracDiv.vhd",
+    "gbaShaderApprox.vhd",
+    "gridGen.vhd",
+    "imageGen.sv",
+    "lineBuffer.vhd",
+    "lineCache.vhd",
+    "osd.vhd",
+    "pwm2pcm.vhd",
+    "singeLineBuffer.vhd",
+    "smooth.vhd",
+    "topUnit.sv",
+    "pins.xdc"
+]

--- a/hdl/imageGen.sv
+++ b/hdl/imageGen.sv
@@ -302,7 +302,8 @@ gridGen ( .pxlInRed( redPxlGBA ),
           
 
 // Smoothing.
-smooth4x ( .rTL( prevLinePrevPxlRedIn ),
+smooth4x smooth4xMod(
+           .rTL( prevLinePrevPxlRedIn ),
            .gTL( prevLinePrevPxlGreenIn ),
            .bTL( prevLinePrevPxlBlueIn ),
            .rTM( prevLineCurPxlRedIn ),

--- a/hdl/topUnit.sv
+++ b/hdl/topUnit.sv
@@ -233,7 +233,7 @@ lineBuffer( .clkW( pxlClk ),
 // Line cache.
 wire [7:0] pxlCntReadToCache;
 logic cacheUpdate;
-lineCache( .clk( pxlClk ),
+lineCache lineCache( .clk( pxlClk ),
            .rst( rst ),
            .curPxlCnt( pxlCntReadToCache ),
            .lineChange( cacheUpdate ),
@@ -281,7 +281,7 @@ lineCache( .clk( pxlClk ),
 
 
 // Image generation.
-imageGenV ( .pxlClk( pxlClk ),
+imageGenV imageGenV ( .pxlClk( pxlClk ),
             .pxlClk5x( pxlClkx5 ),
             .rst( rst ),
              

--- a/syn/spartan/Manifest.py
+++ b/syn/spartan/Manifest.py
@@ -1,0 +1,14 @@
+action = "synthesis"
+
+syn_device = "xc7s15"
+syn_package = "ftgb196"
+syn_grade = "-1"
+syn_tool = "vivado"
+syn_top = "topUnit"
+syn_project = "gbahd.xpr"
+
+syn_fail_on_timing = False
+
+modules = {
+    "local": ["../../hdl", "../../../hdmi/src"]
+}


### PR DESCRIPTION
This allows building with hdlmake.  It requires the [develop branch](https://ohwr.org/project/hdl-make/tree/develop) which has some changes to allow it to work for gbahd.

This currently assumes that the hdmi block checkout is next to gbahd.  It should probably be a git submodule.