### PR TITLE
HDMI Tweaks

### DIFF
--- a/hdl/imageGen.sv
+++ b/hdl/imageGen.sv
@@ -105,7 +105,8 @@ localparam int gbaVideoYStop = gbaVideoYStart + ( maxScaleCnt + 1 ) * 160;
 
 hdmi #( .VIDEO_ID_CODE(VIDEOID), 
         .DVI_OUTPUT(0), 
-        .VIDEO_REFRESH_RATE(60.0), 
+        .VIDEO_REFRESH_RATE(60.0),
+        .IT_CONTENT(1),
         .AUDIO_RATE(48000), 
         .AUDIO_BIT_WIDTH(AUDIO_BIT_WIDTH),
         .START_X(gbaVideoXStart),


### PR DESCRIPTION
This builds on https://github.com/zwenergy/gbaHD/pull/11.  It requires https://github.com/zwenergy/hdmi/pull/1 in your hdmi fork.

This uses the alternate method for setting the starting coordinates of hdmi output and synchronizing it with the GBA.  It also explicitly asks for the IT content flag.