### PR TITLE
pwm2pcm: fix unconnected signal

### DIFF
--- a/hdl/pwm2pcm.sv
+++ b/hdl/pwm2pcm.sv
@@ -189,6 +189,7 @@ module channel(
     upsampler up(
         .clk(clk),
         .rst(rst),
+        .max(max),
         .in(sample),
         .out(pcm)
     );


### PR DESCRIPTION
This has less effect on the output than you would think.