### PR TITLE
Add BlueRetro spiffs image packaging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      
+
       - uses: dorny/paths-filter@v2
         id: changes
         with:
@@ -33,6 +33,12 @@ jobs:
             - 'bitstream/**'
       - name: get_bitstream_version
         run: chmod +x .github/get_bitstream_version.sh && .github/get_bitstream_version.sh bitstream/default_720p.bit
+        shell: bash
+      - name: get_spiffs_script
+        run: curl https://raw.githubusercontent.com/espressif/esp-idf/master/components/spiffs/spiffsgen.py -o ./spiffsgen.py
+        shell: bash
+      - name: package_spiffs_image
+        run: for file in bitstream/*; do mkdir $(basename $file); cp $file $(basename $file)/bitstream.bit; python spiffsgen.py 0xF0000 $(basename $file)/ $(basename $file)_blueretro.bin; done
         shell: bash
       - uses: marvinpinto/action-automatic-releases@v1.2.1
         # uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
@@ -46,5 +52,5 @@ jobs:
           # Assets to upload to the release
           files: |
             bitstream/*.bit
+            *.bin
         if: steps.changes.outputs.bitstream == 'true'
-        


### PR DESCRIPTION
I added support in my BlueRetro project for GBAHD.

See: https://www.youtube.com/watch?v=rHwp4AsUtfE
https://github.com/darthcloud/BlueRetro/wiki/BlueRetro-Consolize-Build-Instructions#game-boy-advance

This include loading the FPGA bitstream from a SPIFFS partition and also support for the OSD via the 1 wire bus.

I'm replacing the SEA board arduino firmware with BlueRetro and using the SDCARD and QSPI pins for the GBA buttons.

As such the bitstream need to be packaged into a spiffs partition to be embedded in the ESP32 flash.

This pull request add support for doing so automatically. It get the spiffs script from espressif and then package the bitstream into an image that are uploaded along side the bitstream in the release.

The way the script work, update on change only, after merging this I think it wont reupload the release as the bitstream are identical. Will only do so on your next bitstream release.

Meanwhile if you accept this PR you could manually add the BlueRetro bitstream image by taking them from my own release here in my fork:
https://github.com/darthcloud/gbaHD/releases/tag/v1.3H